### PR TITLE
Add support for Fennec F-Droid as search provider

### DIFF
--- a/lawnchair/src/ch/deletescape/lawnchair/globalsearch/providers/FirefoxSearchProvider.kt
+++ b/lawnchair/src/ch/deletescape/lawnchair/globalsearch/providers/FirefoxSearchProvider.kt
@@ -44,6 +44,7 @@ open class FirefoxSearchProvider(context: Context) : SearchProvider(context) {
 
     open fun getPackage(context: Context) = listOf(
             "org.mozilla.firefox",
+            "org.mozilla.fennec_fdroid",
             "org.mozilla.firefox_beta",
             "org.mozilla.fennec_aurora"
     ).firstOrNull { PackageManagerHelper.isAppEnabled(context.packageManager, it, 0) }


### PR DESCRIPTION
[Fennec F-Droid](https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/) is a fork of Firefox maintained by the F-Droid community, "_focused on removing any proprietary bits found in official Mozilla's builds_". It is mostly the same browser as the latest stable version of Firefox except for branding.

P.S.: Maybe the user should be allowed to select Firefox version instead of doing `firstOrNull`?